### PR TITLE
fixes #7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,12 +6,12 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 21.11b1
+    rev: 24.1.1
     hooks:
     -   id: black
         args: [--line-length=79]
         name: Make Black formatting
--   repo: https://gitlab.com/PyCQA/flake8
+-   repo: https://github.com/PyCQA/flake8
     rev: 3.9.2
     hooks:
     -   id: flake8

--- a/hungarian_loss/ops.py
+++ b/hungarian_loss/ops.py
@@ -1,4 +1,5 @@
 """A collection of supporting operations."""
+
 import tensorflow as tf
 
 from .const import ZERO

--- a/hungarian_loss/steps.py
+++ b/hungarian_loss/steps.py
@@ -144,6 +144,8 @@ def scratch_matrix(matrix: tf.Tensor) -> tf.Tensor:
             The 2D-tensor column mask, where `True` values indicates the
             scratched columns and `False` intact columns accordingly.
     """
+    NEXT_SCRATCH_ROWS = 0
+    NEXT_SCRATCH_COLS = 1
 
     def scratch_row(zeros_mask, scratched_rows_mask, scratched_cols_mask):
         scratched_row_mask = get_row_mask_with_max_zeros(zeros_mask)
@@ -153,7 +155,12 @@ def scratch_matrix(matrix: tf.Tensor) -> tf.Tensor:
         new_zeros_mask = tf.logical_and(
             zeros_mask, tf.logical_not(expand_item_mask(scratched_row_mask))
         )
-        return new_zeros_mask, new_scratched_rows_mask, scratched_cols_mask
+        return (
+            new_zeros_mask,
+            new_scratched_rows_mask,
+            scratched_cols_mask,
+            NEXT_SCRATCH_COLS,
+        )
 
     def scratch_col(zeros_mask, scratched_rows_mask, scratched_cols_mask):
         scratched_col_mask = get_col_mask_with_max_zeros(zeros_mask)
@@ -163,36 +170,56 @@ def scratch_matrix(matrix: tf.Tensor) -> tf.Tensor:
         new_zeros_mask = tf.logical_and(
             zeros_mask, tf.logical_not(expand_item_mask(scratched_col_mask))
         )
-        return new_zeros_mask, scratched_rows_mask, new_scratched_cols_mask
+        return (
+            new_zeros_mask,
+            scratched_rows_mask,
+            new_scratched_cols_mask,
+            NEXT_SCRATCH_ROWS,
+        )
 
-    def body(zeros_mask, scratched_rows_mask, scratched_cols_mask):
+    def body(
+        zeros_mask, scratched_rows_mask, scratched_cols_mask, scratch_next
+    ):
+        max_zeros_in_rows = (tf.reduce_max(count_zeros_in_rows(zeros_mask)),)
+        max_zeros_in_cols = (tf.reduce_max(count_zeros_in_cols(zeros_mask)),)
         return tf.cond(
-            tf.math.greater(
-                tf.reduce_max(count_zeros_in_rows(zeros_mask)),
-                tf.reduce_max(count_zeros_in_cols(zeros_mask)),
+            tf.math.equal(max_zeros_in_rows, max_zeros_in_cols),
+            true_fn=lambda: tf.cond(
+                tf.math.equal(scratch_next, NEXT_SCRATCH_ROWS),
+                true_fn=lambda: scratch_row(
+                    zeros_mask, scratched_rows_mask, scratched_cols_mask
+                ),
+                false_fn=lambda: scratch_col(
+                    zeros_mask, scratched_rows_mask, scratched_cols_mask
+                ),
             ),
-            true_fn=lambda: scratch_row(
-                zeros_mask, scratched_rows_mask, scratched_cols_mask
-            ),
-            false_fn=lambda: scratch_col(
-                zeros_mask, scratched_rows_mask, scratched_cols_mask
+            false_fn=lambda: tf.cond(
+                tf.math.greater(max_zeros_in_rows, max_zeros_in_cols),
+                true_fn=lambda: scratch_row(
+                    zeros_mask, scratched_rows_mask, scratched_cols_mask
+                ),
+                false_fn=lambda: scratch_col(
+                    zeros_mask, scratched_rows_mask, scratched_cols_mask
+                ),
             ),
         )
 
-    def condition(zeros_mask, scratched_rows_mask, scratched_cols_mask):
+    def condition(
+        zeros_mask, scratched_rows_mask, scratched_cols_mask, scratch_next
+    ):
         return tf.reduce_any(zeros_mask)
 
     num_of_rows, num_of_cols = matrix.shape
-    _, scratched_rows_mask, scratched_cols_mask = tf.while_loop(
+    _, scratched_rows_mask, scratched_cols_mask, _ = tf.while_loop(
         condition,
         body,
         [
             tf.math.equal(matrix, ZERO),
             tf.zeros((num_of_rows, 1), tf.bool),
             tf.zeros((1, num_of_cols), tf.bool),
+            NEXT_SCRATCH_ROWS,
         ],
     )
-
     return scratched_rows_mask, scratched_cols_mask
 
 

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -40,7 +40,7 @@ def test_task_2():
 
 
 def test_task_3():
-    """Tests optimal assignment mask on task #2."""
+    """Tests optimal assignment mask on task #3."""
     matrix = tf.constant(
         [
             [38.0, 53.0, 61.0, 36.0, 66.0],
@@ -59,6 +59,30 @@ def test_task_3():
             [False, True, False, False, False],
             [False, False, False, True, False],
             [False, False, True, False, False],
+        ],
+        tf.bool,
+    )
+    assert tf.reduce_all(tf.equal(actual_mask, expected_mask))
+
+
+def test_task_4():
+    """Tests optimal assignment mask on task #4."""
+    matrix = tf.constant(
+        [
+            [0.0, 9.0, 7.0, 5.0],
+            [4.0, 2.0, 0.0, 9.0],
+            [7.0, 5.0, 4.0, 2.0],
+            [0.0, 9.0, 7.0, 5.0],
+        ],
+        tf.float32,
+    )
+    actual_mask = select_optimal_assignment_mask(reduce_matrix(matrix))
+    expected_mask = tf.constant(
+        [
+            [True, False, False, False],
+            [False, False, True, False],
+            [False, True, False, False],
+            [False, False, False, True],
         ],
         tf.bool,
     )

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -71,9 +71,23 @@ def test_scratch_matrix():
     assert tf.reduce_all(tf.equal(actual_row_mask, expected_row_mask))
     expected_col_mask = tf.constant([[False, False, True]], tf.bool)
     assert tf.reduce_all(tf.equal(actual_col_mask, expected_col_mask))
+
     matrix = tf.constant(
-        [[15.0, 15.0, 0.0], [0.0, 0.0, 10.0], [5.0, 5.0, 0.0]], tf.float32
+        [
+            [0.0, 5.0, 5.0, 5.0],
+            [5.0, 0.0, 10.0, 5.0],
+            [10.0, 10.0, 0.0, 15.0],
+            [10.0, 5.0, 5.0, 0.0],
+        ],
+        tf.float32,
     )
+    actual_row_mask, actual_col_mask = scratch_matrix(matrix)
+    expected_row_mask = tf.constant(
+        [[True], [False], [True], [False]], tf.bool
+    )
+    assert tf.reduce_all(tf.equal(actual_row_mask, expected_row_mask))
+    expected_col_mask = tf.constant([[False, True, False, True]], tf.bool)
+    assert tf.reduce_all(tf.equal(actual_col_mask, expected_col_mask))
 
 
 def test_is_optimal_assignment():
@@ -146,19 +160,35 @@ def test_reduce_matrix():
 
 def test_select_optimal_assignment_mask():
     """Tests the `select_optimal_assignment_mask` function."""
+    # Test scenario 1
     matrix = tf.constant(
         [[10.0, 10.0, 0.0], [0.0, 0.0, 15.0], [0.0, 0.0, 0.0]], tf.float32
     )
     actual_mask = select_optimal_assignment_mask(matrix)
-    expected_mask_1 = tf.constant(
+    expected_mask = tf.constant(
         [[False, False, True], [True, False, False], [False, True, False]],
         tf.bool,
     )
-    expected_mask_2 = tf.constant(
-        [[False, False, True], [False, True, False], [True, False, False]],
+    assert tf.reduce_all(tf.equal(actual_mask, expected_mask))
+
+    # Test scenario 2
+    matrix = tf.constant(
+        [
+            [0.0, 1.0, 1.0, 0.0],
+            [10.0, 0.0, 0.0, 10.0],
+            [10.0, 0.0, 1.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0],
+        ],
+        tf.float32,
+    )
+    actual_mask = select_optimal_assignment_mask(matrix)
+    expected_mask = tf.constant(
+        [
+            [True, False, False, False],
+            [False, False, True, False],
+            [False, True, False, False],
+            [False, False, False, True],
+        ],
         tf.bool,
     )
-    assert tf.logical_or(
-        tf.reduce_all(tf.equal(actual_mask, expected_mask_1)),
-        tf.reduce_all(tf.equal(actual_mask, expected_mask_2)),
-    )
+    assert tf.reduce_all(tf.equal(actual_mask, expected_mask))


### PR DESCRIPTION
When maximum numbers of zeros in columns and rows are equal, scratching of columns and rows alternates. The fixes issue #7 :

```python
from hungarian_loss.steps import (
    reduce_matrix,
    select_optimal_assignment_mask,
)
import tensorflow as tf
import numpy as np

cost = np.array(
    [[0., 9., 7., 5.],
     [4., 2., 0., 9.],
     [7., 5., 4., 2.],
     [0., 9., 7., 5.]]
)
cost = tf.cast(tf.constant(cost), tf.float32)
select_optimal_assignment_mask(reduce_matrix(cost))
```
output
```text
tf.Tensor(
[[ True False False False]
 [False False  True False]
 [False  True False False]
 [False False False  True]], shape=(4, 4), dtype=bool)
```
For a comparison the `scipy` library produces the identical result:

```python
import scipy
import numpy as np

cost = np.array(
    [[0., 9., 7., 5.],
     [4., 2., 0., 9.],
     [7., 5., 4., 2.],
     [0., 9., 7., 5.]]
)
scipy.optimize.linear_sum_assignment(cost)
```
output
```text
(array([0, 1, 2, 3]), array([0, 2, 1, 3]))
```